### PR TITLE
Fix key error when checking domain

### DIFF
--- a/ckanext/geoview/plugin/__init__.py
+++ b/ckanext/geoview/plugin/__init__.py
@@ -94,7 +94,13 @@ class OLGeoView(GeoViewMixin, GeoViewBase):
 
     def can_view(self, data_dict):
         format_lower = data_dict["resource"].get("format", "").lower()
-        same_domain = on_same_domain(data_dict)
+        same_domain = False
+        try:
+            same_domain = on_same_domain(data_dict)
+        except KeyError as e:
+            log.error(
+                "Unable to determine if url is on same domain: {}".format(e)
+            )
 
         # Guess from file extension
         if not format_lower and data_dict["resource"].get("url"):
@@ -141,7 +147,13 @@ class OLGeoView(GeoViewMixin, GeoViewBase):
     def setup_template_variables(self, context, data_dict):
         import ckanext.resourceproxy.plugin as proxy
 
-        same_domain = on_same_domain(data_dict)
+        same_domain = False
+        try:
+            same_domain = on_same_domain(data_dict)
+        except KeyError as e:
+            log.error(
+                "Unable to determine if url is on same domain: {}".format(e)
+            )
 
         if not data_dict["resource"].get("format"):
             data_dict["resource"][
@@ -192,7 +204,13 @@ class GeoJSONView(GeoViewBase):
 
         format_lower = resource.get("format", "").lower()
 
-        same_domain = on_same_domain(data_dict)
+        same_domain = False
+        try:
+            same_domain = on_same_domain(data_dict)
+        except KeyError as e:
+            log.error(
+                "Unable to determine if url is on same domain: {}".format(e)
+            )
 
         if format_lower in self.GeoJSON:
             return same_domain or self.proxy_enabled


### PR DESCRIPTION
## Description
This PR adds a fix for a KeyError when a resource is created/updated and has no url field.

Below is an error log of when a resource in a harvested dataset had no url.
```
Error importing dataset : KeyError('url',) 
Traceback (most recent call last):
  File "/src/ckanext-dcat/ckanext/dcat/harvesters/_json.py", line 315, in import_stage
    package_id = p.toolkit.get_action(action)(context, package_dict)
  File "/usr/lib/ckan/default/src/ckan/ckan/logic/__init__.py", line 457, in wrapped
    result = _action(context, data_dict, **kw)
  File "/usr/lib/ckan/default/src/ckan/ckan/logic/action/create.py", line 221, in package_create
    {'package': data})
  File "/usr/lib/ckan/default/src/ckan/ckan/logic/__init__.py", line 457, in wrapped
    result = _action(context, data_dict, **kw)
  File "/usr/lib/ckan/default/src/ckan/ckan/logic/action/create.py", line 491, in package_create_default_resource_views
    create_datastore_views=create_datastore_views)
  File "/usr/lib/ckan/default/src/ckan/ckan/lib/datapreview.py", line 303, in add_views_to_dataset_resources
    create_datastore_views)
  File "/usr/lib/ckan/default/src/ckan/ckan/lib/datapreview.py", line 261, in add_views_to_resource
    'package': dataset_dict
  File "/src/ckanext-geoview/ckanext/geoview/plugin/__init__.py", line 195, in can_view
    same_domain = on_same_domain(data_dict)
  File "/usr/lib/ckan/default/src/ckan/ckan/lib/datapreview.py", line 58, in on_same_domain
    resource_url = data_dict['resource']['url']
KeyError: 'url'
``` 