### PR TITLE
Fix resource name check

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include README.rst
 include LICENSE
 include bower.json
-recursive-include ckanext/geoview *.html *.json *.js *.less *.css *.config *.png *.gif *.jpg
+recursive-include ckanext/geoview *.html *.json *.js *.less *.css *.config *.png *.gif *.jpg *.yml

--- a/ckanext/geoview/plugin/__init__.py
+++ b/ckanext/geoview/plugin/__init__.py
@@ -286,8 +286,9 @@ class SHPView(GeoViewBase):
     def can_view(self, data_dict):
         resource = data_dict["resource"]
         format_lower = resource["format"].lower()
+        name_lower = resource.get("name", "").lower()
 
-        if format_lower in self.SHP:
+        if format_lower in self.SHP or any([shp in name_lower for shp in self.SHP]):
             return self.same_domain or self.proxy_enabled
         return False
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.0.17'
+version = '0.0.18'
 
 setup(
     name='ckanext-geoview',


### PR DESCRIPTION
## Description
This PR fixes an error that occurs when a resource name is set to a null value.
The error is `AttributeError: 'NoneType' object has no attribute 'lower'`.

This situation can happen in custom dataset schemas when the ckanext-fluent extension is used to provide a multilingual field for the resource name.